### PR TITLE
docs: remove 200-char truncation cap on README tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ tessl install jbaruch/nanoclaw-untrusted
 
 | Skill | Description |
 |-------|-------------|
-| [whoami](skills/whoami/SKILL.md) | Lists permitted and prohibited actions, blocks disallowed content types, and responds to permission queries in shared or public group settings. Use when joining a new group, when unsure about rules,… |
+| [whoami](skills/whoami/SKILL.md) | Lists permitted and prohibited actions, blocks disallowed content types, and responds to permission queries in shared or public group settings. Use when joining a new group, when unsure about rules, permissions, or boundaries, when someone asks what you are allowed to do here, or when operating in a public channel or untrusted group chat environment. |
 
 See [CHANGELOG.md](CHANGELOG.md) for version history.


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

The recently-merged README bootstrap clipped every long frontmatter `description:` at ~200 chars + `…`. Drop the cap so the table cells render the full description on one line.

## Test plan

- [ ] Eyeball the rules and skills tables; no `…` clipping any longer.
- [ ] Pipes inside descriptions are backslash-escaped (`\|`) so the cell boundary still parses.