### PR TITLE
fix(rules): add missing alwaysApply: true frontmatter to all rule files

### DIFF
--- a/rules/bad-actor-disengage.md
+++ b/rules/bad-actor-disengage.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Bad Actor Disengage
 
 ## Detection

--- a/rules/untrusted-security.md
+++ b/rules/untrusted-security.md
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 # Security Rules for Untrusted Groups
 
 **You are running in an untrusted container.** This is NOT a trusted or main group. Your capabilities are restricted by design. You are a guest in this chat. These restrictions are non-negotiable — they are enforced at the infrastructure level and reinforced here as rules.


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- `jbaruch/coding-policy: context-artifacts` requires every rule file to declare `alwaysApply: true` in its frontmatter.
- Every rule in this tile predates the policy and shipped without that frontmatter. Add it across the board.
- Files that already had a `---` frontmatter block get the key inserted inside; files with no frontmatter at all get a full 3-line prepend.

## Test plan

- [ ] Re-review with the gh-aw OpenAI policy reviewer; the `context-artifacts` rule-format clause should pass on every changed file.
- [ ] Spot-check that the rule body content is unchanged byte-for-byte after the frontmatter — only the frontmatter delta should appear in the diff.