### PR TITLE
docs: placeholder values in .env.example per no-secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,10 @@
 # (CODEX_API_KEY takes precedence).
 
 # OpenAI / Codex reviewer credential
-CODEX_API_KEY=
-OPENAI_API_KEY=
+CODEX_API_KEY=replace-with-your-openai-or-codex-api-key
+OPENAI_API_KEY=replace-with-your-openai-or-codex-api-key
 # Anthropic (Claude) reviewer credential
-ANTHROPIC_API_KEY=
+ANTHROPIC_API_KEY=replace-with-your-anthropic-api-key
 # Tessl registry token for the reviewer's `tessl install jbaruch/coding-policy` step
 # Generate at https://tessl.io/account/api-keys
-TESSL_TOKEN=
+TESSL_TOKEN=replace-with-your-tessl-token


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

The `.env.example` shipped with empty secret assignments; `jbaruch/coding-policy: no-secrets` requires placeholder VALUES. This swaps the empty values for clearly-fake placeholders. Fleet-wide normalization; upstream skill follow-up: jbaruch/coding-policy#103.