### PR TITLE
ci(publish): pin workflow actions to immutable SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Renewal mechanism for the SHA-pinned actions in
+# .github/workflows/publish-plugin.yml per `jbaruch/coding-policy:
+# dependency-management`. Dependabot proposes a reviewed bump PR per new
+# release; pins stay immutable between bumps. Matches the sibling
+# nanoclaw-core config. Note: the gh-aw lock files
+# (review-*.lock.yml) also live under .github/workflows/ and pin their
+# own actions; Dependabot PRs touching lock files are regenerated via
+# `gh aw compile` rather than merged directly.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(ci)
+    labels:
+      - dependencies

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -14,13 +14,16 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to immutable SHAs per `jbaruch/coding-policy:
+      # dependency-management`. Renewal: Dependabot (github-actions
+      # ecosystem, weekly) proposes bump PRs — see .github/dependabot.yml.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Required by jbaruch/coding-policy/.github/actions/skill-review:
           # the action runs `git diff $BEFORE..HEAD` to find changed skills.
           fetch-depth: 0
 
-      - uses: tesslio/setup-tessl@v2
+      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
 
@@ -37,6 +40,6 @@ jobs:
       - name: Lint plugin
         run: tessl plugin lint .
 
-      - uses: tesslio/patch-version-publish@v1
+      - uses: tesslio/patch-version-publish@d1363877846ebf6bc09e032e2dc8612f1d7e38dd # v1
         with:
           token: ${{ secrets.TESSL_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.38 — 2026-07-08
+
+### CI
+
+- Pin `actions/checkout`, `tesslio/setup-tessl`, and `tesslio/patch-version-publish` in `publish-plugin.yml` to immutable commit SHAs per `jbaruch/coding-policy: dependency-management` (closes #16). The publish job holds `contents: write` and the registry token; floating major tags let a moved tag change the trusted publish path without a reviewed diff here.
+- Add `.github/dependabot.yml` (github-actions ecosystem, weekly) as the stated renewal mechanism for the pins, matching the sibling nanoclaw-core config.
+
 ## 0.1.37 — 2026-07-07
 
 ### Rules — one response protocol for hostile interactions (#17, #18, #21)


### PR DESCRIPTION
**Author-Model:** claude-fable-5

## Summary
- **CI-scoped PR (announced scope):** pin `actions/checkout@v4`, `tesslio/setup-tessl@v2`, and `tesslio/patch-version-publish@v1` in `publish-plugin.yml` to immutable commit SHAs (closes #16). The job has `contents: write` and uses `TESSL_TOKEN`; a moved tag currently changes the trusted publish path with no reviewed diff here. SHAs verified two ways: resolved from the current tag objects via the GitHub API, and cross-checked against the SHAs the last green publish run actually downloaded.
- Add `.github/dependabot.yml` (github-actions ecosystem, weekly) as the stated renewal mechanism per `jbaruch/coding-policy: dependency-management`, matching the sibling nanoclaw-core config. The config header notes that Dependabot PRs touching gh-aw `*.lock.yml` files are regenerated via `gh aw compile` rather than merged directly.

## Test plan
- [x] YAML parses (workflow + dependabot config)
- [x] Pinned SHAs match both the live tag objects and the last green run's resolved downloads
- [ ] Publish workflow green on merge; registry advances past 0.1.37; moderation clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG4ME699cJ8g6VtL6cy2Kk