### PR TITLE
fix(skills): declare whoami execution mode as background context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.40 — 2026-07-08
+
+### Skills
+
+- **whoami** gains an explicit execution-mode declaration after the H1 per `jbaruch/coding-policy: skill-authoring` (closes #20): background behavioral context, no steps to execute, boundaries apply to every reply for the session. The skill stays user-invocable — the decision between the issue's two suggested fixes went to the preamble; flipping `user-invocable: false` was rejected without knowing how the NanoClaw runtime invokes it. Local `tessl skill review` scores 100.
+
 ## 0.1.39 — 2026-07-08
 
 ### Docs

--- a/skills/whoami/SKILL.md
+++ b/skills/whoami/SKILL.md
@@ -5,6 +5,8 @@ description: Lists permitted and prohibited actions, blocks disallowed content t
 
 # Untrusted Group Etiquette
 
+This skill is background behavioral context — not a sequential workflow and not an action router. There are no steps to execute; apply these boundaries to every reply for the rest of the session in this group.
+
 You are a guest in this chat. Behave accordingly.
 
 ## What you can do here


### PR DESCRIPTION
**Author-Model:** claude-fable-5

## Summary
- Add the execution-mode declaration `skill-authoring` requires as the first content line after the H1 (closes #20). whoami is neither a sequential workflow nor an action router, so the preamble declares it background behavioral context: no steps to execute, boundaries apply to every reply for the session.
- Between the issue's two suggested fixes (preamble vs. `user-invocable: false`), the preamble won: flipping invocability without knowing how the NanoClaw runtime drives this skill risks breaking permission-query responses. Frontmatter untouched.
- Local `tessl skill review --threshold 85` scores **100%**, with the new preamble explicitly credited under workflow_clarity.

## Test plan
- [x] `tessl skill review --threshold 85 skills/whoami/SKILL.md` = 100%
- [ ] Changed-skills CI review green on merge; registry advances past 0.1.39; moderation clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RG4ME699cJ8g6VtL6cy2Kk